### PR TITLE
fix: Update CODEOWNERS to own top level files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,9 @@
 *                     @statcan/daaas
 
 # Codeowners is restricted
-CODEOWNERS            @statcan/daaas-admins
-LICENSE               @statcan/daaas-admins
-LICENSE.md            @statcan/daaas-admins
+/CODEOWNERS            @statcan/daaas-admins
+/LICENSE               @statcan/daaas-admins
+/LICENSE.md            @statcan/daaas-admins
 
 # Workflows are restricted
 /.github/workflows/   @statcan/daaas-workflows


### PR DESCRIPTION
Previous version set review structure around **any** `LICENSE.md`, etc., file as `daaas-admins`.  So for example a user updating their `/some-dashboard/LICENSE.md` would trigger a `daaas-admins` review